### PR TITLE
Declare $template before it is passed over to plugin events.

### DIFF
--- a/framework/library/astroid/Admin.php
+++ b/framework/library/astroid/Admin.php
@@ -87,7 +87,8 @@ class Admin extends Helper\Client
     {
         $this->format = 'html'; // Response Format
         $document = Framework::getDocument();
-
+        $template = Framework::getTemplate();
+ 
         Framework::getDebugger()->log('Loading Forms');
         $form = Framework::getForm();
         Helper::triggerEvent('onBeforeAstroidFormLoad', [&$template, &$form]);
@@ -98,8 +99,6 @@ class Admin extends Helper\Client
         Framework::getDebugger()->log('Loading Forms');
 
         $this->checkAndRedirect(); // Auth
-
-        $template = Framework::getTemplate();
         $form->loadParams($template->getParams());
 
         Framework::getDebugger()->log('Loading Languages');


### PR DESCRIPTION
- Related issue: https://github.com/templaza/astroid-framework/issues/67
- Otherwise the `$template` variable is null when used in plugins.
- And a check like `if ($template->isAstroid)` fails always with a PHP warning: `Warning: Attempt to read property "isAstroid" on null in plugins/system/astroid/xxyz.php`
