### PR TITLE
Fix PHP >= 8.1 Warning: Passing null to parameter of type string is deprecated .. Utility.php on line 353 and 379

### DIFF
--- a/framework/library/astroid/Component/Utility.php
+++ b/framework/library/astroid/Component/Utility.php
@@ -350,7 +350,13 @@ class Utility
         $document->addCustomTag($params->get('trackingcode', ''));
         $document->addStyleDeclaration($params->get('customcss', ''));
 
-        $customcssfiles = explode("\n", $params->get('customcssfiles'));
+	$paramcustomcssfiles = $params->get('customcssfiles');
+	if (isset($paramcustomcssfiles) && $paramcustomcssfiles) {
+        	$customcssfiles = explode("\n", $paramcustomcssfiles);
+	}
+	else {
+		$customcssfiles = array();
+	}
 
         foreach ($customcssfiles as $customcssfile) {
             @list($file, $shift) = \explode('|', $customcssfile);
@@ -376,7 +382,13 @@ class Utility
         $document->addCustomTag($params->get('astroid_trackingcode', ''));
         $document->addStyleDeclaration($params->get('astroid_customcss', ''));
 
-        $customcssfiles = explode("\n", $params->get('astroid_customcssfiles'));
+	$paramastroidcustomcssfiles = $params->get('astroid_customcssfiles');
+	if (isset($paramastroidcustomcssfiles) && $paramastroidcustomcssfiles) {
+        	$customcssfiles = explode("\n", $paramastroidcustomcssfiles);
+	}
+	else {
+		$customcssfiles = array();
+	}
 
         foreach ($customcssfiles as $customcssfile) {
             @list($file, $shift) = \explode('|', $customcssfile);


### PR DESCRIPTION
Since php 8.1 it is deprecated to pass null parameters to explode and other functions. Better check for null and set the variable to a fallback value.