### PR TITLE
Default value for $this->params->get('sass_overrides'

### DIFF
--- a/framework/library/astroid/Template.php
+++ b/framework/library/astroid/Template.php
@@ -195,7 +195,7 @@ class Template
 
     protected function _variableOverrides($variables)
     {
-        $sass_overrides = $this->params->get('sass_overrides');
+        $sass_overrides = $this->params->get('sass_overrides', '{}');
         $sass_overrides = \json_decode($sass_overrides, true);
         if (empty($sass_overrides)) {
             return $variables;


### PR DESCRIPTION
With PHP8.2 message `json_decode(): Passing null to parameter #1 ($json) of type string is deprecated`.

We are using an astroid template where the settings for sass overrides are deactivated in the template style.

Therefore the line

`$sass_overrides = $this->params->get('sass_overrides');`

produces a deprecated message in the following line because `$sass_overrides === null`

`$sass_overrides = \json_decode($sass_overrides, true);`

==> `json_decode(): Passing null to parameter #1 ($json) of type string is deprecated`.

This PR adds a default value `'{}'` as fallback when $sass_overrides === null. It doesn't change the functionality of the method because json_decode() now returns an empty array.