### PR TITLE
Changed <a> to <button> for SEO improvements

### DIFF
--- a/framework/frontend/backtotop.php
+++ b/framework/frontend/backtotop.php
@@ -75,5 +75,5 @@ if (!$backtotop_on_mobile) {
    $class[] = 'hideonxs';
 }
 
-$html .= '<a title="Back to Top" id="astroid-backtotop" class="' . implode(' ', $class) . '" href="#"><i class="' . $backtotop_icon . '"></i></a>';
+$html .= '<button type="button" title="Back to Top" id="astroid-backtotop" class="btn ' . implode(' ', $class) . '" ><i class="' . $backtotop_icon . '"></i></button>';
 echo $html;


### PR DESCRIPTION
For the scroll to top, I replaced the `<a>` tag with `<button>` because search engines may use href attributes in links for website crawling. Since this element is intended for an action rather than navigation, using a `<button>` improves semantic correctness and prevents unintended indexing by search engines.