### PR TITLE
Fixes issue #1286

### DIFF
--- a/framework/library/astroid/Helper.php
+++ b/framework/library/astroid/Helper.php
@@ -208,6 +208,11 @@ class Helper
         } else {
             self::clearCSS($template_dir, $prefix);
         }
+
+        $template_font_cache = JPATH_SITE . '/media/templates/site/' . $template . '/fonts.cache.json';
+        if (file_exists($template_font_cache)) {
+            unlink($template_font_cache);
+        }
         return true;
     }
 

--- a/framework/library/astroid/Template.php
+++ b/framework/library/astroid/Template.php
@@ -356,7 +356,11 @@ class Template
     public function getFonts()
     {
         if (self::$fonts === null) {
+            self::$fonts = Helper\Font::getCachedLocalFonts($this->template);
+        }
+        if (self::$fonts === null) {
             self::$fonts = Helper\Font::getUploadedFonts($this->template);
+            Helper\Font::updateCachedLocalFonts($this->template, self::$fonts);
         }
         return self::$fonts;
     }


### PR DESCRIPTION
This commit fixes an issue with astroid making to many reads to local font files to get their info. The patch adds an local font-info cache file that is used to cache local font information.